### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/integration/containerd/cri/integration-tests.sh
+++ b/integration/containerd/cri/integration-tests.sh
@@ -468,7 +468,7 @@ main() {
 	git checkout "${containerd_branch}"
 	
 	# switch to the default pause image set by containerd:1.6.x
-	sed -i 's#k8s.gcr.io/pause:3.[0-9]#k8s.gcr.io/pause:3.6#' integration/main_test.go
+	sed -i 's#registry.k8s.io/pause:3.[0-9]#registry.k8s.io/pause:3.6#' integration/main_test.go
 	cp "${SCRIPT_PATH}/container_restart_test.go.patch" ./integration/container_restart_test.go
 
 	# Make sure the right artifacts are going to be built

--- a/versions.yaml
+++ b/versions.yaml
@@ -35,7 +35,7 @@ container_images:
 
   agnhost:
     description: "Kubernetes host OS agnostic test image"
-    name: "k8s.gcr.io/e2e-test-images/agnhost"
+    name: "registry.k8s.io/e2e-test-images/agnhost"
     # Keep this updated with the Kubernetes version used for testing.
     version: "2.21"
 


### PR DESCRIPTION
This fix is a part of an umbrella issue https://github.com/kubernetes/k8s.io/issues/4780